### PR TITLE
Enforce CRLF line endings for all text files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
-*.lyt text eol=crlf
+*.lyt text
+*.vis text
+*.ascii.mdl text
+*.txi text
+*.nss text
+* text=auto eol=crlf


### PR DESCRIPTION
Updated .gitattributes to enforce CRLF line endings across specified file types. Since K1/2, the game we are modding, requires Windows-style line endings, this change will help prevent issues with text files formatted with LF instead of CRLF. All text files are now set to use CRLF for compatibility with the game's requirements.